### PR TITLE
config: Explicitly set URL for jekyll-feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -123,6 +123,10 @@ feed:
   excerpt_only: true
   icon: "/assets/globussquare.png"
 
+# It looks like jekyll-feed is not automatically setting the URL for posts.
+# So, set the URL explicitly.
+url: https://globus.stanford.edu
+
 # These are Jekyll plugins that we enable.
 # NOTE: We can only use plugins that GitHub makes available.
 # The list is here: https://pages.github.com/versions/


### PR DESCRIPTION
For some reason, the Atom feed being produced by jekyll-feed was not including the full URL for posts.  jekyll-feed was producing absolute URLs (like `/feed.xml`), not fully-qualified URLs (like `https://globus.stanford.edu/feed.xml`).  Try setting the URL explicitly in site config.